### PR TITLE
[2/2] Install and run agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # BOSH Release for datadog-agent
 
+This release only supports Ubuntu Trusty stemcells - it uses the python-dev apt package.
+Packaging requires Internet connectivity - Python packages are downloaded to the install target.
+
 ## Usage
 
 To use this bosh release, first upload it to your bosh:
 
 ```
 bosh target BOSH_HOST
-git clone https://github.com/cloudfoundry-community/datadog-agent-boshrelease.git
+git clone https://github.com/onemedical/datadog-agent-boshrelease.git
 cd datadog-agent-boshrelease
 bosh upload release
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,48 @@ cd datadog-agent-boshrelease
 bosh upload release
 ```
 
-### Development
+Configure the agent on each of your instance groups:
+
+```
+instance_groups:
+- name: myservice
+  jobs:
+  - name: datadog-agent
+    release: datadog-agent
+    properties:
+      api_key: abc123...
+      tags:
+        service: myservice
+```
+
+### Collecting AWS tags
+
+To collect AWS tags, set up a Datadog role following the [Datadog instructions](http://docs.datadoghq.com/integrations/aws/).
+Instead of creating a "Role for Cross-Account Access," create an "Amazon EC2" role.
+Use that role name in your cloud config and enable EC2 tag collection on the instance group:
+
+```
+vm_extensions:
+- name: datadog
+  cloud_properties:
+    iam_instance_profile: datadog-instance-profile
+```
+
+```
+instance_groups:
+- name: myservice
+  vm_extensions: [datadog]
+  jobs:
+  - name: datadog-agent
+    release: datadog-agent
+    properties:
+      api_key: abc123...
+      collect_ec2_tags: true
+      tags:
+        service: myservice
+```
+
+## Development
 
 As a developer of this release, create new releases and upload them:
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,1 +1,69 @@
---- {}
+---
+virtualenv/virtualenv-1.11.6.py:
+  object_id: 5fe339bd-9bc2-4112-a6e3-bc6c013c5e9b
+  sha: a506a836ef76301bc19e5a209984a4286529a79b
+  size: 98477
+datadog-agent/agent.tar.gz:
+  object_id: f10d0d4f-1867-4f0c-a0b9-c2ec1638cab6
+  sha: 470b815e4cfc087e29bce6037456326fe916726e
+  size: 7112750
+datadog-agent/ez_setup.py:
+  object_id: dc2d372d-0f51-4447-a2ed-b1960f3c58eb
+  sha: 6f4ad84d852b9eb3132035cfd88dbd212714a48c
+  size: 12402
+datadog-agent/get-pip.py:
+  object_id: 5211ca17-6b2c-4d35-ba72-929b077e2827
+  sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
+  size: 1524722
+datadog-agent/requirements-opt.txt:
+  object_id: 3a6257bc-785d-4e28-be52-8172b5b9df7f
+  sha: 8d23e59ce93ef2cbb000440a5a260a4cde1a2a4e
+  size: 1478
+datadog-agent/requirements.txt:
+  object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
+  sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d
+  size: 1926
+apt/python-dev/libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb:
+  object_id: 6ee9956a-7645-46f6-9893-9c1255de9bde
+  sha: 70b2766fb83200073459dab66709f14bbb8fef57
+  size: 115202
+apt/python-dev/libexpat1_2.1.0-4ubuntu1.3_amd64.deb:
+  object_id: 3c144009-5eb5-4a4a-8948-ef93c5f46f2e
+  sha: b9a62f58c76a4f917defef9b0bce2a15197306ac
+  size: 71134
+apt/python-dev/libpython-dev_2.7.5-5ubuntu3_amd64.deb:
+  object_id: 15812c5d-d189-4c17-b9c2-3fb27cb62421
+  sha: 8ea63c31b460a972f230e89deddde1a1cc978317
+  size: 7078
+apt/python-dev/libpython2.7-dev_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: abd0605f-33de-4610-87d5-a106bc3c5227
+  sha: ed8980613989d581af60c30ec5c97384c3e5d44f
+  size: 22007718
+apt/python-dev/libpython2.7-minimal_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: d7b1c38e-8aa4-437e-9a04-aac64997036e
+  sha: d8dcfb156026bbf451502eef0fc0376fa3fabefc
+  size: 307916
+apt/python-dev/libpython2.7-stdlib_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: ccd4d6ff-9858-43ed-81cc-850d7e602fed
+  sha: b3a639145df0e1fd76a98cb4c6f1ac08f2c4de2f
+  size: 1869374
+apt/python-dev/libpython2.7_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: 1e291ab2-c6a5-4726-8540-e2dd937c6b9c
+  sha: 2660bd56f54a2601d227bd4a43641db7d8e2bfcc
+  size: 1038642
+apt/python-dev/python-dev_2.7.5-5ubuntu3_amd64.deb:
+  object_id: f06b0c4c-2f81-496d-a4a5-0a8f278e1b01
+  sha: 13e6be388dae2131d3ac6c17242fe28f2d6b6b3d
+  size: 1166
+apt/python-dev/python2.7-dev_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: c776461c-77bc-42db-8849-4865b3b4c0d3
+  sha: 3239f647321900abf034bed6be6bac2f66158954
+  size: 269106
+apt/python-dev/python2.7-minimal_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: 5ceb380e-7890-439f-aea6-af4caa06fa8f
+  sha: 984bfe30245a2e757341b0c9abb16f97ae51b0b8
+  size: 1185096
+apt/python-dev/python2.7_2.7.6-8ubuntu0.2_amd64.deb:
+  object_id: 48a21a13-f31d-4794-9033-69cdb47dfe05
+  sha: b87ff6940cd17466e867a5e1e6f70fbca14cfe0c
+  size: 195822

--- a/jobs/datadog-agent/monit
+++ b/jobs/datadog-agent/monit
@@ -1,0 +1,17 @@
+check process datadog-agent-collector
+  with pidfile /var/vcap/sys/tmp/datadog-agent/dd-agent.pid
+  start program "/var/vcap/jobs/datadog-agent/bin/monit_debugger collector_ctl '/var/vcap/jobs/datadog-agent/bin/collector_ctl start'"
+  stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger collector_ctl '/var/vcap/jobs/datadog-agent/bin/collector_ctl stop'"
+  group vcap
+
+check process datadog-agent-forwarder
+  with pidfile /var/vcap/sys/run/datadog-agent/forwarder.pid
+  start program "/var/vcap/jobs/datadog-agent/bin/monit_debugger forwarder_ctl '/var/vcap/jobs/datadog-agent/bin/forwarder_ctl start'"
+  stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger forwarder_ctl '/var/vcap/jobs/datadog-agent/bin/forwarder_ctl stop'"
+  group vcap
+
+check process datadog-agent-dogstatsd
+  with pidfile /var/vcap/sys/run/datadog-agent/dogstatsd.pid
+  start program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl start'"
+  stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl stop'"
+  group vcap

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -1,0 +1,24 @@
+---
+name: datadog-agent
+packages:
+- datadog-agent
+templates:
+  bin/collector_ctl: bin/collector_ctl
+  bin/dogstatsd_ctl: bin/dogstatsd_ctl
+  bin/forwarder_ctl: bin/forwarder_ctl
+  bin/monit_debugger: bin/monit_debugger
+  config/datadog.conf.erb: config/datadog.conf
+  data/properties.sh.erb: data/properties.sh
+  helpers/ctl_setup.sh: helpers/ctl_setup.sh
+  helpers/ctl_utils.sh: helpers/ctl_utils.sh
+
+properties:
+  api_key:
+    description: Datadog API key
+  collect_ec2_tags:
+    description: Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
+  hostname:
+    description: Hostname as it should be displayed within datadog. Optional.
+  tags:
+    default: {}
+    description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/datadog-agent/helpers/ctl_setup.sh 'datadog-agent'
+
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+# hard-coded in agent.py to use this path
+PIDFILE=$TMP_DIR/dd-agent.pid
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
+    export LANG=POSIX
+
+    python "$AGENT_DIR/agent.py" foreground --use-local-forwarder \
+      >>$LOG_DIR/collector.log 2>&1
+
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: datadog-agent_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/datadog-agent/templates/bin/dogstatsd_ctl
+++ b/jobs/datadog-agent/templates/bin/dogstatsd_ctl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/datadog-agent/helpers/ctl_setup.sh 'datadog-agent'
+
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+PIDFILE=$RUN_DIR/dogstatsd.pid
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    # store pid in $PIDFILE
+    echo $$ > $PIDFILE
+
+    cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    exec chpst -u vcap:vcap \
+      python "$AGENT_DIR/dogstatsd.py" --use-local-forwarder \
+      >>$LOG_DIR/dogstatsd.log 2>&1
+
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: datadog-agent_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup env vars and folders for the webapp_ctl script
+source /var/vcap/jobs/datadog-agent/helpers/ctl_setup.sh 'datadog-agent'
+
+export PORT=${PORT:-5000}
+export LANG=en_US.UTF-8
+PIDFILE=$RUN_DIR/forwarder.pid
+
+case $1 in
+
+  start)
+    pid_guard $PIDFILE $JOB_NAME
+
+    # store pid in $PIDFILE
+    echo $$ > $PIDFILE
+
+    cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    exec chpst -u vcap:vcap \
+      python "$AGENT_DIR/ddagent.py" --use_simple_http_client=1 \
+      >>$LOG_DIR/forwarder.log 2>&1
+
+    ;;
+
+  stop)
+    kill_and_wait $PIDFILE
+
+    ;;
+  *)
+    echo "Usage: datadog-agent_ctl {start|stop}"
+
+    ;;
+
+esac
+exit 0

--- a/jobs/datadog-agent/templates/bin/monit_debugger
+++ b/jobs/datadog-agent/templates/bin/monit_debugger
@@ -1,0 +1,13 @@
+#!/bin/sh
+# USAGE monit_debugger <label> command to run
+mkdir -p /var/vcap/sys/log/monit
+{
+  echo "MONIT-DEBUG date"
+  date
+  echo "MONIT-DEBUG env"
+  env
+  echo "MONIT-DEBUG $@"
+  $2 $3 $4 $5 $6 $7
+  R=$?
+  echo "MONIT-DEBUG exit code $R"
+} >/var/vcap/sys/log/monit/monit_debugger.$1.log 2>&1

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -1,0 +1,234 @@
+[Main]
+
+# The host of the Datadog intake server to send Agent data to
+dd_url: https://app.datadoghq.com
+
+# If you need a proxy to connect to the Internet, provide the settings here
+# proxy_host: my-proxy.com
+# proxy_port: 3128
+# proxy_user: user
+# proxy_password: password
+# To be used with some proxys that return a 302 which make curl switch from POST to GET
+# See http://stackoverflow.com/questions/8156073/curl-violate-rfc-2616-10-3-2-and-switch-from-post-to-get
+# proxy_forbid_method_switch: no
+
+# If you run the agent behind haproxy, you might want to set this to yes
+# skip_ssl_validation: no
+
+# The Datadog api key to associate your Agent's data with your organization.
+# Can be found here:
+# https://app.datadoghq.com/account/settings
+api_key: <%= p('api_key') %>
+
+<% if_p('hostname') do %>
+# Force the hostname to whatever you want.
+hostname: <%= p('hostname') %>
+<% end %>
+
+# Set the host's tags
+<% if p('tags').any? %>
+tags: <%= p('tags').map { |k, v| "#{k}:#{v}" }.join(', ') %>
+<% end %>
+
+# Add one "dd_check:checkname" tag per running check. It makes it possible to slice
+# and dice per monitored app (= running Agent Check) on Datadog's backend.
+# create_dd_check_tags: no
+
+# Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
+<% if_p('collect_ec2_tags') do %>
+collect_ec2_tags: <%= p('collect_ec2_tags') %>
+<% end %>
+
+# Incorporate security-groups into tags collected from AWS EC2
+# collect_security_groups: no
+
+# Enable Agent Developer Mode
+# Agent Developer Mode collects and sends more fine-grained metrics about agent and check performance
+# developer_mode: no
+# In developer mode, the number of runs to be included in a single collector profile
+# collector_profile_interval: 20
+
+# use unique hostname for GCE hosts, see http://dtdg.co/1eAynZk
+gce_updated_hostname: yes
+
+# Set the threshold for accepting points to allow anything
+# with recent_point_threshold seconds
+# Defaults to 30 seconds if no value is provided
+# recent_point_threshold: 30
+
+# Use mount points instead of volumes to track disk and fs metrics
+# DEPRECATED: use conf.d/disk.yaml instead to configure it
+use_mount: no
+
+# Change port the Agent is listening to
+# listen_port: 17123
+
+# Start a graphite listener on this port
+# graphite_listen_port: 17124
+
+# Additional directory to look for Datadog checks
+# additional_checksd: /etc/dd-agent/checks.d/
+
+# Allow non-local traffic to this Agent
+# This is required when using this Agent as a proxy for other Agents
+# that might not have an internet connection
+# For more information, please see
+# https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
+# non_local_traffic: no
+
+# Select the Tornado HTTP Client in the forwarder
+# Default to the simple http client
+# use_curl_http_client: False
+
+# The loopback address the Forwarder and Dogstatsd will bind.
+# Optional, it is mainly used when running the agent on Openshift
+# bind_host: localhost
+
+# If enabled the collector will capture a metric for check run times.
+# check_timings: no
+
+# If you want to remove the 'ww' flag from ps catching the arguments of processes
+# for instance for security reasons
+# exclude_process_args: no
+
+# histogram_aggregates: max, median, avg, count
+# histogram_percentiles: 0.95
+
+# ========================================================================== #
+# Service Discovery                                                          #
+# See https://github.com/DataDog/dd-agent/wiki/Service-Discovery for details #
+# ========================================================================== #
+#
+# Service discovery allows the agent to look for running services
+# and load a configuration object for the one it recognizes.
+# This feature is disabled by default.
+# Uncomment this line to enable it (works for docker containers only for now).
+# service_discovery_backend: docker
+#
+# Define which key/value store must be used to look for configuration templates.
+# Default is etcd. Consul is also supported.
+# sd_config_backend: etcd
+#
+# Settings for connecting to the service discovery backend.
+# sd_backend_host: 127.0.0.1
+# sd_backend_port: 4001
+#
+# By default, the agent will look for the configuration templates under the
+# `/datadog/check_configs` key in the back-end. If you wish otherwise, uncomment this option
+# and modify its value.
+# sd_template_dir: /datadog/check_configs
+
+# ========================================================================== #
+# DogStatsd configuration                                                    #
+# ========================================================================== #
+
+# If you don't want to enable the DogStatsd server, set this option to no
+# use_dogstatsd: yes
+
+# DogStatsd is a small server that aggregates your custom app metrics. For
+# usage information, check out http://docs.datadoghq.com/guides/dogstatsd/
+
+#  Make sure your client is sending to the same port.
+# dogstatsd_port : 8125
+
+# By default dogstatsd will post aggregate metrics to the Agent (which handles
+# errors/timeouts/retries/etc). To send directly to the datadog api, set this
+# to https://app.datadoghq.com.
+# dogstatsd_target : http://localhost:17123
+
+# If you want to forward every packet received by the dogstatsd server
+# to another statsd server, uncomment these lines.
+# WARNING: Make sure that forwarded packets are regular statsd packets and not "dogstatsd" packets,
+# as your other statsd server might not be able to handle them.
+# statsd_forward_host: address_of_own_statsd_server
+# statsd_forward_port: 8125
+
+# you may want all statsd metrics coming from this host to be namespaced
+# in some way; if so, configure your namespace here. a metric that looks
+# like `metric.name` will instead become `namespace.metric.name`
+# statsd_metric_namespace:
+
+# By default, dogstatsd supports only plain ASCII packets. However, most
+# (dog)statsd client support UTF8 by encoding packets before sending them
+# this option enables UTF8 decoding in case you need it.
+# However, it comes with a performance overhead of ~10% in the dogstatsd
+# server. This will be taken care of properly in the new gen agent core.
+# utf8_decoding: false
+
+# ========================================================================== #
+# Service-specific configuration                                             #
+# ========================================================================== #
+
+# -------------------------------------------------------------------------- #
+#   Ganglia                                                                  #
+# -------------------------------------------------------------------------- #
+
+# Ganglia host where gmetad is running
+#ganglia_host: localhost
+
+# Ganglia port where gmetad is running
+#ganglia_port: 8651
+
+# -------------------------------------------------------------------------- #
+#  Dogstream (log file parser)
+# -------------------------------------------------------------------------- #
+
+# Comma-separated list of logs to parse and optionally custom parsers to use.
+# The form should look like this:
+#
+#   dogstreams: /path/to/log1:parsers_module:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Or this:
+#
+#   dogstreams: /path/to/log1:/path/to/my/parsers_module.py:custom_parser, /path/to/log2, /path/to/log3, ...
+#
+# Each entry is a path to a log file and optionally a Python module/function pair
+# separated by colons.
+#
+# Custom parsers should take a 2 parameters, a logger object and
+# a string parameter of the current line to parse. It should return a tuple of
+# the form:
+#   (metric (str), timestamp (unix timestamp), value (float), attributes (dict))
+# where attributes should at least contain the key 'metric_type', specifying
+# whether the given metric is a 'counter' or 'gauge'.
+#
+# Unless parsers are specified with an absolute path, the modules must exist in
+# the Agent's PYTHONPATH. You can set this as an environment variable when
+# starting the Agent. If the name of the custom parser function is not passed,
+# 'parser' is assumed.
+#
+# If this value isn't specified, the default parser assumes this log format:
+#     metric timestamp value key0=val0 key1=val1 ...
+#
+
+# ========================================================================== #
+# Custom Emitters                                                            #
+# ========================================================================== #
+
+# Comma-separated list of emitters to be used in addition to the standard one
+#
+# Expected to be passed as a comma-separated list of colon-delimited
+# name/object pairs.
+#
+# custom_emitters: /usr/local/my-code/emitters/rabbitmq.py:RabbitMQEmitter
+#
+# If the name of the emitter function is not specified, 'emitter' is assumed.
+
+
+# ========================================================================== #
+# Logging
+# ========================================================================== #
+
+# log_level: INFO
+
+collector_log_file: /var/vcap/sys/log/datadog-agent/collector.log
+forwarder_log_file: /var/vcap/sys/log/datadog-agent/forwarder.log
+dogstatsd_log_file: /var/vcap/sys/log/datadog-agent/dogstatsd.log
+jmxfetch_log_file: /var/vcap/sys/log/datadog-agent/jmxfetch.log
+
+# if syslog is enabled but a host and port are not set, a local domain socket
+# connection will be attempted
+#
+log_to_syslog: no
+# syslog_host:
+# syslog_port:

--- a/jobs/datadog-agent/templates/data/properties.sh.erb
+++ b/jobs/datadog-agent/templates/data/properties.sh.erb
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# job template binding variables
+
+# job name & index of this VM within cluster
+# e.g. JOB_NAME=redis, JOB_INDEX=0
+export NAME='<%= name %>'
+export JOB_INDEX=<%= index %>
+# full job name, like redis/0 or webapp/3
+export JOB_FULL="$NAME/$JOB_INDEX"
+
+export AGENT_DIR="$JOB_DIR/packages/datadog-agent/agent"
+
+export PATH="$JOB_DIR/packages/datadog-agent/venv/bin:$PATH"
+source $JOB_DIR/packages/datadog-agent/venv/bin/activate

--- a/jobs/datadog-agent/templates/helpers/ctl_setup.sh
+++ b/jobs/datadog-agent/templates/helpers/ctl_setup.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# Setup env vars and folders for the ctl script
+# This helps keep the ctl script as readable
+# as possible
+
+# Usage options:
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh JOB_NAME OUTPUT_LABEL
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar foobar
+# source /var/vcap/jobs/foobar/helpers/ctl_setup.sh foobar nginx
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+JOB_NAME=$1
+output_label=${2:-${JOB_NAME}}
+
+export JOB_DIR=/var/vcap/jobs/$JOB_NAME
+chmod 755 $JOB_DIR # to access file via symlink
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
+
+source $JOB_DIR/helpers/ctl_utils.sh
+redirect_output ${output_label}
+
+export HOME=${HOME:-/home/vcap}
+
+# Setup the PATH and LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-''} # default to empty
+for package_dir in $(ls -d /var/vcap/packages/*)
+do
+  has_busybox=0
+  # Add all packages' /bin & /sbin into $PATH
+  for package_bin_dir in $(ls -d ${package_dir}/*bin)
+  do
+    # Do not add any packages that use busybox, as impacts builtin commands and
+    # is often used for different architecture (via containers)
+    if [ -f ${package_bin_dir}/busybox ]
+    then
+      has_busybox=1
+    else
+      export PATH=${package_bin_dir}:$PATH
+    fi
+  done
+  if [ "$has_busybox" == "0" ] && [ -d ${package_dir}/lib ]
+  then
+    export LD_LIBRARY_PATH=${package_dir}/lib:$LD_LIBRARY_PATH
+  fi
+done
+
+# Setup log, run and tmp folders
+
+export RUN_DIR=/var/vcap/sys/run/$JOB_NAME
+export LOG_DIR=/var/vcap/sys/log/$JOB_NAME
+export TMP_DIR=/var/vcap/sys/tmp/$JOB_NAME
+export STORE_DIR=/var/vcap/store/$JOB_NAME
+for dir in $RUN_DIR $LOG_DIR $TMP_DIR $STORE_DIR
+do
+  mkdir -p ${dir}
+  chown vcap:vcap ${dir}
+  chmod 775 ${dir}
+done
+export TMPDIR=$TMP_DIR
+
+export C_INCLUDE_PATH=/var/vcap/packages/mysqlclient/include/mysql:/var/vcap/packages/sqlite/include:/var/vcap/packages/libpq/include
+export LIBRARY_PATH=/var/vcap/packages/mysqlclient/lib/mysql:/var/vcap/packages/sqlite/lib:/var/vcap/packages/libpq/lib
+
+# consistent place for vendoring python libraries within package
+if [[ -d ${WEBAPP_DIR:-/xxxx} ]]
+then
+  export PYTHONPATH=$WEBAPP_DIR/vendor/lib/python
+fi
+
+if [[ -d /var/vcap/packages/java7 ]]
+then
+  export JAVA_HOME="/var/vcap/packages/java7"
+fi
+
+# setup CLASSPATH for all jars/ folders within packages
+export CLASSPATH=${CLASSPATH:-''} # default to empty
+for java_jar in $(ls -d /var/vcap/packages/*/*/*.jar)
+do
+  export CLASSPATH=${java_jar}:$CLASSPATH
+done
+
+PIDFILE=$RUN_DIR/$output_label.pid
+
+echo '$PATH' $PATH

--- a/jobs/datadog-agent/templates/helpers/ctl_utils.sh
+++ b/jobs/datadog-agent/templates/helpers/ctl_utils.sh
@@ -1,0 +1,155 @@
+# Helper functions used by ctl scripts
+
+# links a job file (probably a config file) into a package
+# Example usage:
+# link_job_file_to_package config/redis.yml [config/redis.yml]
+# link_job_file_to_package config/wp-config.php wp-config.php
+link_job_file_to_package() {
+  source_job_file=$1
+  target_package_file=${2:-$source_job_file}
+  full_package_file=$WEBAPP_DIR/${target_package_file}
+
+  link_job_file ${source_job_file} ${full_package_file}
+}
+
+# links a job file (probably a config file) somewhere
+# Example usage:
+# link_job_file config/bashrc /home/vcap/.bashrc
+link_job_file() {
+  source_job_file=$1
+  target_file=$2
+  full_job_file=$JOB_DIR/${source_job_file}
+
+  echo link_job_file ${full_job_file} ${target_file}
+  if [[ ! -f ${full_job_file} ]]
+  then
+    echo "file to link ${full_job_file} does not exist"
+  else
+    # Create/recreate the symlink to current job file
+    # If another process is using the file, it won't be
+    # deleted, so don't attempt to create the symlink
+    mkdir -p $(dirname ${target_file})
+    ln -nfs ${full_job_file} ${target_file}
+  fi
+}
+
+# If loaded within monit ctl scripts then pipe output
+# If loaded from 'source ../utils.sh' then normal STDOUT
+redirect_output() {
+  SCRIPT=$1
+  mkdir -p /var/vcap/sys/log/monit
+  exec 1>> /var/vcap/sys/log/monit/$SCRIPT.log 2>&1
+}
+
+pid_guard() {
+  pidfile=$1
+  name=$2
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+
+    if [ -n "$pid" ] && [ -e /proc/$pid ]; then
+      echo "$name is already running, please stop it first"
+      exit 1
+    fi
+
+    echo "Removing stale pidfile..."
+    rm $pidfile
+  fi
+}
+
+wait_pid() {
+  pid=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  echo wait_pid $pid $try_kill $timeout $force $countdown
+  if [ -e /proc/$pid ]; then
+    if [ "$try_kill" = "1" ]; then
+      echo "Killing $pidfile: $pid "
+      kill $pid
+    fi
+    while [ -e /proc/$pid ]; do
+      sleep 0.1
+      [ "$countdown" != '0' -a $(( $countdown % 10 )) = '0' ] && echo -n .
+      if [ $timeout -gt 0 ]; then
+        if [ $countdown -eq 0 ]; then
+          if [ "$force" = "1" ]; then
+            echo -ne "\nKill timed out, using kill -9 on $pid... "
+            kill -9 $pid
+            sleep 0.5
+          fi
+          break
+        else
+          countdown=$(( $countdown - 1 ))
+        fi
+      fi
+    done
+    if [ -e /proc/$pid ]; then
+      echo "Timed Out"
+    else
+      echo "Stopped"
+    fi
+  else
+    echo "Process $pid is not running"
+    echo "Attempting to kill pid anyway..."
+    kill $pid
+  fi
+}
+
+wait_pidfile() {
+  pidfile=$1
+  try_kill=$2
+  timeout=${3:-0}
+  force=${4:-0}
+  countdown=$(( $timeout * 10 ))
+
+  if [ -f "$pidfile" ]; then
+    pid=$(head -1 "$pidfile")
+    if [ -z "$pid" ]; then
+      echo "Unable to get pid from $pidfile"
+      exit 1
+    fi
+
+    wait_pid $pid $try_kill $timeout $force
+
+    rm -f $pidfile
+  else
+    echo "Pidfile $pidfile doesn't exist"
+  fi
+}
+
+kill_and_wait() {
+  pidfile=$1
+  # Monit default timeout for start/stop is 30s
+  # Append 'with timeout {n} seconds' to monit start/stop program configs
+  timeout=${2:-25}
+  force=${3:-1}
+  if [[ -f ${pidfile} ]]
+  then
+    wait_pidfile $pidfile 1 $timeout $force
+  else
+    # TODO assume $1 is something to grep from 'ps ax'
+    pid="$(ps auwwx | grep "$1" | awk '{print $2}')"
+    wait_pid $pid 1 $timeout $force
+  fi
+}
+
+check_nfs_mount() {
+  opts=$1
+  exports=$2
+  mount_point=$3
+
+  if grep -qs $mount_point /proc/mounts; then
+    echo "Found NFS mount $mount_point"
+  else
+    echo "Mounting NFS..."
+    mount $opts $exports $mount_point
+    if [ $? != 0 ]; then
+      echo "Cannot mount NFS from $exports to $mount_point, exiting..."
+      exit 1
+    fi
+  fi
+}

--- a/packages/datadog-agent/packaging
+++ b/packages/datadog-agent/packaging
@@ -1,0 +1,40 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Detect # of CPUs so make jobs can be parallelized
+CPUS=$(grep -c ^processor /proc/cpuinfo)
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+DEPENDENCY_DIR="$(cd $BOSH_INSTALL_TARGET/.. && pwd)"
+
+AGENT_VERSION="5.8.5"
+DD_START_AGENT=0
+PIP_VERSION=6.1.1
+SETUPTOOLS_VERSION=20.9.0
+
+mkdir -p $BOSH_INSTALL_TARGET/bin
+cp -LR $DEPENDENCY_DIR/virtualenv $BOSH_INSTALL_TARGET/venv
+source $BOSH_INSTALL_TARGET/venv/bin/activate
+
+source $DEPENDENCY_DIR/python-dev/profile.sh
+
+VENV_PYTHON_CMD="$BOSH_INSTALL_TARGET/venv/bin/python"
+VENV_PIP_CMD="$BOSH_INSTALL_TARGET/venv/bin/pip"
+
+$VENV_PYTHON_CMD datadog-agent/ez_setup.py --version="$SETUPTOOLS_VERSION" --to-dir=$BOSH_INSTALL_TARGET
+$VENV_PYTHON_CMD datadog-agent/get-pip.py
+$VENV_PIP_CMD install "pip==$PIP_VERSION" --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
+$VENV_PIP_CMD install -r datadog-agent/requirements.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
+set +e
+$VENV_PIP_CMD install -r datadog-agent/requirements-opt.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
+set -e
+
+rm -f "$BOSH_INSTALL_TARGET/setuptools-$SETUPTOOLS_VERSION.zip"
+rm -f "$BOSH_INSTALL_TARGET/ez_setup.py"
+rm -f "$BOSH_INSTALL_TARGET/ez_setup.pyc"
+rm -f "$BOSH_INSTALL_TARGET/get-pip.py"
+rm -f "$BOSH_INSTALL_TARGET/get-pip.pyc"
+rm -f "$BOSH_INSTALL_TARGET/requirements.txt"
+
+mkdir -p $BOSH_INSTALL_TARGET/agent
+tar xzf datadog-agent/agent.tar.gz -C $BOSH_INSTALL_TARGET/agent --strip-components 1

--- a/packages/datadog-agent/spec
+++ b/packages/datadog-agent/spec
@@ -1,0 +1,11 @@
+---
+name: datadog-agent
+dependencies:
+- python-dev
+- virtualenv
+files:
+- datadog-agent/agent.tar.gz
+- datadog-agent/ez_setup.py
+- datadog-agent/get-pip.py
+- datadog-agent/requirements.txt
+- datadog-agent/requirements-opt.txt

--- a/packages/python-dev/packaging
+++ b/packages/python-dev/packaging
@@ -1,0 +1,14 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+mkdir -p $BOSH_INSTALL_TARGET/apt
+
+for DEB in $(ls -1 apt/python-dev/*.deb); do
+  echo "Installing $(basename $DEB)"
+  dpkg -x $DEB $BOSH_INSTALL_TARGET/apt
+done
+
+cp -a apt/python-dev/profile.sh $BOSH_INSTALL_TARGET/

--- a/packages/python-dev/spec
+++ b/packages/python-dev/spec
@@ -1,0 +1,6 @@
+---
+name: python-dev
+dependencies: []
+files:
+- apt/python-dev/profile.sh
+- apt/python-dev/*.deb

--- a/packages/virtualenv/packaging
+++ b/packages/virtualenv/packaging
@@ -1,0 +1,11 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Detect # of CPUs so make jobs can be parallelized
+CPUS=$(grep -c ^processor /proc/cpuinfo)
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+VIRTUALENV_VERSION="1.11.6"
+
+python virtualenv/virtualenv-$VIRTUALENV_VERSION.py --no-pip --no-setuptools $BOSH_INSTALL_TARGET

--- a/packages/virtualenv/spec
+++ b/packages/virtualenv/spec
@@ -1,0 +1,5 @@
+---
+name: virtualenv
+dependencies: []
+files:
+- virtualenv/virtualenv-1.11.6.py

--- a/src/apt/fetch_debs.sh
+++ b/src/apt/fetch_debs.sh
@@ -1,0 +1,70 @@
+set -e          # exit immediately if a simple command exits with a non-zero status
+set -u          # report the usage of uninitialized variables
+set -o pipefail # return value of a pipeline is the value of the last (rightmost) command to exit with a non-zero status
+
+# Usage: src/common/fetch_debs.sh postgresql [src/apt/postgresql]
+#
+#   src/common/fetch_debs.sh postgresql
+#   src/common/fetch_debs.sh postgresql src/apt/postgresql
+#
+PACKAGE_NAME=$1
+RELEASE_DIR=${RELEASE_DIR:-/vagrant}
+if [[ "${2:-X}" == "X" ]]; then
+    PACKAGE_SRC_DIR=$RELEASE_DIR/src/apt/$PACKAGE_NAME
+else
+    PACKAGE_SRC_DIR=$RELEASE_DIR/$2
+fi
+APTFILE=$PACKAGE_SRC_DIR/aptfile
+APT_CACHE_DIR="$RELEASE_DIR/tmp/apt/cache/$PACKAGE_NAME"
+APT_STATE_DIR="$RELEASE_DIR/tmp/apt/state"
+BLOBS_DIR=$RELEASE_DIR/blobs/apt/$PACKAGE_NAME
+
+function error() {
+  echo " !     $*" >&2
+  exit 1
+}
+
+function topic() {
+  echo "-----> $*"
+}
+
+function indent() {
+  c='s/^/       /'
+  case $(uname) in
+    Darwin) sed -l "$c";;
+    *)      sed -u "$c";;
+  esac
+}
+
+topic "Environment information"
+echo $0                | indent
+uname -a               | indent
+pwd                    | indent
+
+# Invoke apt-get to ensure it exists
+if [[ "$(which apt-get)X" == "X" ]]; then
+    error "Cannot find apt-get executable. Run this script within a Debian/Ubuntu environment."
+fi
+which apt-get          | indent
+
+echo $APTFILE          | indent
+if [[ ! -f $APTFILE ]]; then
+    error "Missing source file $APTFILE"
+fi
+
+mkdir -p "$APT_CACHE_DIR/archives/partial"
+mkdir -p "$APT_STATE_DIR/lists/partial"
+mkdir -p $BLOBS_DIR
+
+APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
+
+topic "Updating apt caches"
+apt-get $APT_OPTIONS update | indent
+
+for PACKAGE in $(cat $APTFILE); do
+  topic "Fetching .debs for $PACKAGE"
+  apt-get $APT_OPTIONS -y -d install $PACKAGE | indent
+done
+
+topic "Copying .debs to blobs"
+cp -a $APT_CACHE_DIR/archives/*.deb $BLOBS_DIR/

--- a/src/apt/python-dev/aptfile
+++ b/src/apt/python-dev/aptfile
@@ -1,0 +1,1 @@
+python-dev

--- a/src/apt/python-dev/profile.sh
+++ b/src/apt/python-dev/profile.sh
@@ -1,0 +1,4 @@
+export LD_LIBRARY_PATH="/var/vcap/packages/python-dev/apt/usr/lib:${LD_LIBRARY_PATH:-}"
+export INCLUDE_PATH="/var/vcap/packages/python-dev/apt/usr/include:${INCLUDE_PATH:-}"
+export CPATH="$INCLUDE_PATH"
+export CPPPATH="$INCLUDE_PATH"


### PR DESCRIPTION
Installs and runs the datadog agent.

The agent runs on Python, and installs dependencies with pip. To shortcut a bunch more work, I'm using the `python-dev` Ubuntu package, so this will only work on Ubuntu stemcells.

I also skipped setting up `jmxfetch` because I didn't want to also install Java. Can always add it as a second job.