### PR TITLE
[2/2] Support agent integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ instance_groups:
         service: myservice
 ```
 
+### Agent integrations
+
+Some Datadog integrations are configured in the agent: https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d
+They might depend on "optional" dependencies in the agent: https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt
+The `datadog-agent` package installs these but some fail due to missing dependencies.
+These packages are skipped:
+
+* `pgbouncer` depends on `libpq`, which this release does not include
+* `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
+* `win32_event_log` and `wmi` will only work on Windows
+
 ## Development
 
 As a developer of this release, create new releases and upload them:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ These packages are skipped:
 * `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
 * `win32_event_log` and `wmi` will only work on Windows
 
+Configure integrations by embedding the YAML in the properties:
+
+```
+instance_groups:
+- name: myservice
+  jobs:
+  - name: datadog-agent
+    release: datadog-agent
+    properties:
+      integrations:
+        process:
+          init_config:
+            pid_cache_duration: 30
+          instances:
+          - name: myservice
+            search_string: ["myservice"]
+            thresholds:
+              critical: [1, 9]
+```
+
 ## Development
 
 As a developer of this release, create new releases and upload them:

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -16,9 +16,9 @@ datadog-agent/get-pip.py:
   sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
   size: 1524722
 datadog-agent/requirements-opt.txt:
-  object_id: 3a6257bc-785d-4e28-be52-8172b5b9df7f
-  sha: 8d23e59ce93ef2cbb000440a5a260a4cde1a2a4e
-  size: 1478
+  object_id: 957fa648-9eb3-4673-b2da-391a64042c8d
+  sha: 069e5471ce75437a4427a79109cfd7cd4976a138
+  size: 1484
 datadog-agent/requirements.txt:
   object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
   sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -22,3 +22,8 @@ properties:
   tags:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.
+  integrations:
+    default: {}
+    description: |
+      Agent integration configuration.
+      Each key will have ".yaml" appended to it and the value dumped into that file in `AGENT_DIR/conf.d/`.

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -9,6 +9,7 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 # hard-coded in agent.py to use this path
 PIDFILE=$TMP_DIR/dd-agent.pid
+INTEGRATION_DIR="$AGENT_DIR/conf.d"
 
 case $1 in
 
@@ -16,6 +17,14 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+
+    rm -f "$INTEGRATION_DIR/*"
+    <% p("integrations").each do |integration, config| %>
+    mkdir -p "$INTEGRATION_DIR"
+    cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
+<%= JSON.dump(config) %>
+YAML
+    <% end %>
 
     export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
     export LANG=POSIX

--- a/packages/datadog-agent/packaging
+++ b/packages/datadog-agent/packaging
@@ -26,9 +26,7 @@ $VENV_PYTHON_CMD datadog-agent/ez_setup.py --version="$SETUPTOOLS_VERSION" --to-
 $VENV_PYTHON_CMD datadog-agent/get-pip.py
 $VENV_PIP_CMD install "pip==$PIP_VERSION" --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
 $VENV_PIP_CMD install -r datadog-agent/requirements.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set +e
 $VENV_PIP_CMD install -r datadog-agent/requirements-opt.txt --global-option=build_ext --global-option="-I$INCLUDE_PATH" --global-option="-L$LD_LIBRARY_PATH"
-set -e
 
 rm -f "$BOSH_INSTALL_TARGET/setuptools-$SETUPTOOLS_VERSION.zip"
 rm -f "$BOSH_INSTALL_TARGET/ez_setup.py"

--- a/src/apt/python-dev/profile.sh
+++ b/src/apt/python-dev/profile.sh
@@ -1,4 +1,16 @@
-export LD_LIBRARY_PATH="/var/vcap/packages/python-dev/apt/usr/lib:${LD_LIBRARY_PATH:-}"
-export INCLUDE_PATH="/var/vcap/packages/python-dev/apt/usr/include:${INCLUDE_PATH:-}"
+ld_library_path="/var/vcap/packages/python-dev/apt/usr/lib"
+if [ -n "${LD_LIBRARY_PATH:-}" ]; then
+  export LD_LIBRARY_PATH="$ld_library_path:$LD_LIBRARY_PATH"
+else
+  export LD_LIBRARY_PATH="$ld_library_path"
+fi
+
+include_path="/var/vcap/packages/python-dev/apt/usr/include:/var/vcap/packages/python-dev/apt/usr/include/python2.7"
+if [ -n "${INCLUDE_PATH:-}" ]; then
+  export INCLUDE_PATH="$include_path:$INCLUDE_PATH"
+else
+  export INCLUDE_PATH="$include_path"
+fi
+
 export CPATH="$INCLUDE_PATH"
 export CPPPATH="$INCLUDE_PATH"


### PR DESCRIPTION
I received this question from someone trying to use this release:

> I have tried to monitor processes but it didn't work. Have you tried? Have you tried other extensions?
> I have enabled examples in AGENT_DIR/conf.d but I'm getting python errors. I have added the python_dev package but still the same error.

Looking into this I discovered that:

1. I made the wrong assumption about the optional pip dependencies. I assumed that since the [upstream install script](https://github.com/DataDog/dd-agent/blob/5.8.5/packaging/datadog-agent/source/setup_agent.sh#L391) ignores failures, I should too. These optional dependencies are actually required for some of the integrations, as [documented in `requirements-opt.txt`](https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt).
2. pip dependencies that have native extensions couldn't compile because the `python2.7` include directory was not directly on the `INCLUDE_PATH`. Also, the trailing `:` caused the parser to include an extra `-L` option, breaking the compilation.

This PR supports installation of optional dependencies and adds a property to configure them.

```
instance_groups:
- name: myservice
  jobs:
  - name: datadog-agent
    release: datadog-agent
    properties:
      integrations:
        process:
          init_config:
            pid_cache_duration: 30
          instances:
          - name: myservice
            search_string: ["myservice"]
            thresholds:
              critical: [1, 9]
```