### PR TITLE
Move requirements*.txt to src/ instead of blobs

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -15,14 +15,6 @@ datadog-agent/get-pip.py:
   object_id: 5211ca17-6b2c-4d35-ba72-929b077e2827
   sha: 20da892e83c4f3ae8b523c8a3f8f4e29e935aef7
   size: 1524722
-datadog-agent/requirements-opt.txt:
-  object_id: 957fa648-9eb3-4673-b2da-391a64042c8d
-  sha: 069e5471ce75437a4427a79109cfd7cd4976a138
-  size: 1484
-datadog-agent/requirements.txt:
-  object_id: 0feec7b9-3ca9-4360-bafd-7d699be7edd5
-  sha: b76f6d06e38688f1f512952a9ed2b1ebcb7ece3d
-  size: 1926
 apt/python-dev/libexpat1-dev_2.1.0-4ubuntu1.3_amd64.deb:
   object_id: 6ee9956a-7645-46f6-9893-9c1255de9bde
   sha: 70b2766fb83200073459dab66709f14bbb8fef57

--- a/src/datadog-agent/requirements-opt.txt
+++ b/src/datadog-agent/requirements-opt.txt
@@ -1,0 +1,54 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+# core/optional
+# tornado can work without pycurl and use the simple http client
+# but some features won't work, like the abylity to use a proxy
+# Require a compiler and the curl headers+lib
+# On windows - manual install of pycurl might be easier.
+pycurl==7.19.5.1
+
+# core-ish/system -> system check on windows
+# checks.d/process.py
+# checks.d/gunicorn.py
+# checks.d/btrfs.py
+# checks.d/system_core.py
+psutil==3.3.0
+
+# checks.d/snmp.py
+# Require a compiler because pycrypto is a dep
+pysnmp-mibs==0.1.4
+pysnmp==4.2.5
+
+# checks.d/mongo.py
+# checks.d/tokumx.py
+# Require a compiler
+# TODO: our checks are not compatible with 3.x
+pymongo==3.2
+
+# checks.d/kafka_consumer.py
+# Requires a compiler because zope.interface is a dep
+kazoo==1.3.1
+
+# checks.d/ssh_check.py
+# winrandom-ctypes
+# Require a compiler because pycrypto is a dep
+paramiko==1.15.2
+
+# checks.d/pgbouncer.py
+# Require libpq
+# psycopg2==2.6
+
+# checks.d/win32_event_log.py
+# checks.d/wmi.py
+# It's a pure python module, it doesn't require anything to install,
+# but needs the pywin32 extension to work
+# wmi==1.4.9
+
+# checks.d/directory.py
+scandir==1.2

--- a/src/datadog-agent/requirements.txt
+++ b/src/datadog-agent/requirements.txt
@@ -1,0 +1,78 @@
+######################## WARNING ##########################
+# This file currently determines the python deps installed
+# for the dev env, the source install and the Win build.
+# It is NOT used for the DEB/RPM packages and the OS X
+# build. For these please update:
+# https://github.com/DataDog/omnibus-software
+###########################################################
+
+###########################################################
+# These modules are the deps needed by the
+# agent core, meaning every module that is
+# not a check
+# They're installed in the CI and when doing
+# a source install
+# If their installation fails the agent installation
+# fails, so they shouldn't have too many deps
+###########################################################
+
+boto==2.39.0
+ntplib==0.3.3
+# the libyaml bindings are optional
+pyyaml==3.11
+# note: requests is also used in many checks
+# upgrade with caution
+requests==2.6.0
+# note: simplejson is used in many checks to inteface APIs
+simplejson==3.6.5
+supervisor==3.3.0
+tornado==3.2.2
+uptime==3.0.1
+
+###########################################################
+# These modules are for checks. But they are
+# installable just fine anywhere. So we install
+# them all. They're usually pure python and don't
+# need any external deps.
+###########################################################
+
+# checks.d/sqlserver.py
+adodbapi==2.6.0.7
+pyro4==4.35 # required by adodbapi
+
+# checks.d/riak.py
+httplib2==0.9
+
+# checks.d/kafka_consumer.py
+kafka-python==0.9.3
+
+# checks.d/postgres.py
+pg8000==1.10.1
+
+# checks.d/mysql.py
+pymysql==0.6.6
+
+# checks.d/gearman.py
+gearman==2.0.2
+
+# checks.d/mcache.py
+python-memcached==1.53
+
+# checks.d/redis.py
+redis==2.10.3
+
+# checks.d/vsphere.py
+pyvmomi==6.0.0
+
+# checks.d/hdfs.py
+snakebite==1.3.11
+
+# utils/platform.py
+docker-py==1.8.1
+
+# checks.d/dns_check.py
+dnspython==1.12.0
+
+# utils/service_discovery/config_stores.py
+python-etcd==0.4.2
+python-consul==0.4.7


### PR DESCRIPTION
We want to be able to track and change the files for requirements.txt and
requirements-opt.txt, which are currently managed as external blobs.

This is required to enable different datadog plugins which require
additional python dependencies. Having this file in code will be make it
easier to fork the release and do the required changes, and maintain
changes via PRs.