### PR TITLE
Fix virtualenv python path

### DIFF
--- a/jobs/datadog-agent/templates/helpers/ctl_setup.sh
+++ b/jobs/datadog-agent/templates/helpers/ctl_setup.sh
@@ -18,11 +18,6 @@ output_label=${2:-${JOB_NAME}}
 export JOB_DIR=/var/vcap/jobs/$JOB_NAME
 chmod 755 $JOB_DIR # to access file via symlink
 
-# Load some bosh deployment properties into env vars
-# Try to put all ERb into data/properties.sh.erb
-# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
-source $JOB_DIR/data/properties.sh
-
 source $JOB_DIR/helpers/ctl_utils.sh
 redirect_output ${output_label}
 
@@ -50,6 +45,11 @@ do
     export LD_LIBRARY_PATH=${package_dir}/lib:$LD_LIBRARY_PATH
   fi
 done
+
+# Load some bosh deployment properties into env vars
+# Try to put all ERb into data/properties.sh.erb
+# incl $NAME, $JOB_INDEX, $WEBAPP_DIR
+source $JOB_DIR/data/properties.sh
 
 # Setup log, run and tmp folders
 


### PR DESCRIPTION
The virtualenv was loaded first, then the PATH was changed. Therefore
the python used in the startup script may not be the one from the
virtualenv. This caused problems with other releases that manage other
python installs.

This change moves the activation of the virtualenv after the PATH change
to avoid this issue.