### PR TITLE
Allow optionally disable dogstatsd

### DIFF
--- a/jobs/datadog-agent/monit
+++ b/jobs/datadog-agent/monit
@@ -10,8 +10,10 @@ check process datadog-agent-forwarder
   stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger forwarder_ctl '/var/vcap/jobs/datadog-agent/bin/forwarder_ctl stop'"
   group vcap
 
+<% if p('use_dogstatsd') == 'yes' %>
 check process datadog-agent-dogstatsd
   with pidfile /var/vcap/sys/run/datadog-agent/dogstatsd.pid
   start program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl start'"
   stop program "/var/vcap/jobs/datadog-agent/bin/monit_debugger dogstatsd_ctl '/var/vcap/jobs/datadog-agent/bin/dogstatsd_ctl stop'"
   group vcap
+<% end %>

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -19,6 +19,9 @@ properties:
     description: Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
   hostname:
     description: Hostname as it should be displayed within datadog. Optional.
+  use_dogstatsd:
+    default: yes
+    description: Should the dogstatsd agent be started
   tags:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -123,7 +123,7 @@ use_mount: no
 # ========================================================================== #
 
 # If you don't want to enable the DogStatsd server, set this option to no
-# use_dogstatsd: yes
+use_dogstatsd: <%= p("use_dogstatsd") %>
 
 # DogStatsd is a small server that aggregates your custom app metrics. For
 # usage information, check out http://docs.datadoghq.com/guides/dogstatsd/


### PR DESCRIPTION
Dogstatsd is an agent based on statsd to receive and aggregate metrics.

It may not always be required and may conflict with other statsd agents.

This change allows to disable it.