### PR TITLE
Merge integrations conf from 3rd party jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,16 +57,17 @@ instance_groups:
 
 ### Agent integrations
 
-Some Datadog integrations are configured in the agent: https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d
-They might depend on "optional" dependencies in the agent: https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt
-The `datadog-agent` package installs these but some fail due to missing dependencies.
-These packages are skipped:
+Some [Datadog integrations are configured in the agent](https://github.com/DataDog/dd-agent/tree/5.8.5/conf.d).
+This release has support to configure them.
 
-* `pgbouncer` depends on `libpq`, which this release does not include
-* `ssh_check` depends on `winrandom-ctypes`, which will only install on Windows
-* `win32_event_log` and `wmi` will only work on Windows
+Note: These integrations depend on ["optional" dependencies in the agent](https://github.com/DataDog/dd-agent/blob/5.8.5/requirements-opt.txt).
+The `datadog-agent` package installs these but some fail due to missing dependencies. Currently these packages are not working:
 
-Configure integrations by embedding the YAML in the properties:
+  * `pgbouncer` depends on `libpq`, which this release does not include
+
+#### Configuring integrations adhoc in the manifest
+
+The end user can configure integrations by embedding the YAML in the properties:
 
 ```
 instance_groups:
@@ -85,6 +86,20 @@ instance_groups:
             thresholds:
               critical: [1, 9]
 ```
+
+#### Configuring integrations from 3rd party releases
+
+Third party releases might want to extend datadog agent to monitor local services using these additional checks.
+
+This release has logic to merge all files from jobs which follow this pattern:
+
+  ${JOB_PATH}/config/datadog-integrations/${checkname}.yaml
+
+For example:
+
+  /var/vcap/jobs/datadog-router/config/datadog-integrations/process.yaml
+
+The script will use [spruce](https://github.com/geofffranks/spruce) to merge all the configurations in one unique file per check, as datadog agent expects. Merging the config with spruces allows multiple jobs add configuration for some checks, for instance to monitor different processes. Additionally the release developer can use [the spruce syntax](https://github.com/geofffranks/spruce) if the need to, although default merge strategy is good enough.
 
 ## Development
 

--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -67,3 +67,7 @@ apt/python-dev/python2.7_2.7.6-8ubuntu0.2_amd64.deb:
   object_id: 48a21a13-f31d-4794-9033-69cdb47dfe05
   sha: b87ff6940cd17466e867a5e1e6f70fbca14cfe0c
   size: 195822
+spruce/spruce:
+  object_id: a4b53617-9fb1-4085-b6dd-82b7783b7c9c
+  sha: 233fa7fc416e1213c63711eb7c3f0b94f000d131
+  size: 10594008

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -2,6 +2,7 @@
 name: datadog-agent
 packages:
 - datadog-agent
+- spruce
 templates:
   bin/collector_ctl: bin/collector_ctl
   bin/dogstatsd_ctl: bin/dogstatsd_ctl
@@ -11,6 +12,8 @@ templates:
   data/properties.sh.erb: data/properties.sh
   helpers/ctl_setup.sh: helpers/ctl_setup.sh
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
+  helpers/merge_integrations_conf.sh: helpers/merge_integrations_conf.sh
+  helpers/generate_integrations_conf.sh: helpers/generate_integrations_conf.sh
 
 properties:
   api_key:

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -9,7 +9,6 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 # hard-coded in agent.py to use this path
 PIDFILE=$TMP_DIR/dd-agent.pid
-INTEGRATION_DIR="$AGENT_DIR/conf.d"
 
 case $1 in
 
@@ -17,14 +16,8 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
-
-    rm -f "$INTEGRATION_DIR/*"
-    <% p("integrations").each do |integration, config| %>
-    mkdir -p "$INTEGRATION_DIR"
-    cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
-<%= JSON.dump(config) %>
-YAML
-    <% end %>
+    bash $JOB_DIR/helpers/generate_integrations_conf.sh
+    bash $JOB_DIR/helpers/merge_integrations_conf.sh
 
     export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
     export LANG=POSIX

--- a/jobs/datadog-agent/templates/helpers/generate_integrations_conf.sh
+++ b/jobs/datadog-agent/templates/helpers/generate_integrations_conf.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+set -u
+
+INTEGRATION_DIR="/var/vcap/jobs/datadog-agent/config/datadog-integrations"
+
+mkdir -p "${INTEGRATION_DIR}"
+rm -f "${INTEGRATION_DIR}/*"
+
+<% p("integrations").each do |integration, config| %>
+mkdir -p "$INTEGRATION_DIR"
+cat <<YAML > "$INTEGRATION_DIR/<%= integration %>.yaml"
+<%= JSON.dump(config) %>
+YAML
+<% end %>

--- a/jobs/datadog-agent/templates/helpers/merge_integrations_conf.sh
+++ b/jobs/datadog-agent/templates/helpers/merge_integrations_conf.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+set -u
+
+SPRUCE=/var/vcap/packages/spruce/bin/spruce
+JOBS_PATH=/var/vcap/jobs
+DD_AGENT_HOME=/var/vcap/packages/datadog-agent/agent
+
+rm -f "${DD_AGENT_HOME}"/conf.d/*.yaml
+
+check_file_names=$(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path '*/config/datadog-integrations/*yaml' -printf '%f\n' | sort -u)
+
+for f in ${check_file_names}; do
+  files_to_merge=$(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path "*/config/datadog-integrations/${f}")
+  "${SPRUCE}" merge ${files_to_merge} > "${DD_AGENT_HOME}"/conf.d/"${f}"
+done

--- a/packages/spruce/packaging
+++ b/packages/spruce/packaging
@@ -1,0 +1,11 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+ # Available variables
+# $BOSH_COMPILE_TARGET - where this package & spec'd source files are available
+# $BOSH_INSTALL_TARGET - where you copy/install files to be included in package
+
+BIN=spruce
+mkdir ${BOSH_INSTALL_TARGET}/bin
+cp ${BIN}/${BIN} ${BOSH_INSTALL_TARGET}/bin
+chmod 755 ${BOSH_INSTALL_TARGET}/bin/${BIN}

--- a/packages/spruce/spec
+++ b/packages/spruce/spec
@@ -1,0 +1,5 @@
+---
+name: spruce
+dependencies: []
+files:
+- spruce/spruce


### PR DESCRIPTION
Datadog bundles several additional checks[1] that can run on the host from the collector. These checks usually require some configuration in the `${DD_AGENT_DIR}/conf.d/`[2].

This configuration is in form of YAML files.

Currently we generate these files in the collector ctl script from the manifest properties, but third party releases might also want to  extend datadog to monitor local services using these additional integrations.

To solve that, this commit adds logic to merge all files from jobs which follow this pattern:

    ${JOB_PATH}/config/datadog-integrations/${checkname}.yaml

For example:

    /var/vcap/jobs/datadog-router/config/datadog-integrations/process.yaml

The script will use spruce[3] to merge all the configurations in one unique file per check, as datadog agent expects.

We also extract the logic to generate the integrations config from the manifest to a external helper file, and make it generate the files using the pattern described above.

[1] http://docs.datadoghq.com/integrations/
[2] https://github.com/DataDog/dd-agent/tree/master/conf.d
[3] https://github.com/geofffranks/spruce

Important! Upload the spruce blob
---------------------------------

This PR contains a reference to a blob: compiled spruce for x86_64.

The blob must be uploaded before merging using this. You can do it by running:

```
wget https://github.com/geofffranks/spruce/releases/download/v1.8.1/spruce-linux-amd64
aws s3 cp spruce-linux-amd64 s3://omg-boshrelease-blobs/a4b53617-9fb1-4085-b6dd-82b7783b7c9c
```

Or use bosh_cli and rewrite the related commit.