### PR TITLE
Allow include the bosh spec metadata as tags

### DIFF
--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -25,6 +25,9 @@ properties:
   tags:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.
+  include_bosh_tags:
+    description: Collect bosh spec metadata of the instance job, index and az. These can be overriden by setting them in tags.
+    default: false
   integrations:
     default: {}
     description: |

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -26,8 +26,19 @@ hostname: <%= p('hostname') %>
 <% end %>
 
 # Set the host's tags
-<% if p('tags').any? %>
-tags: <%= p('tags').map { |k, v| "#{k}:#{v}" }.join(', ') %>
+<%
+tags = {}
+if p('include_bosh_tags')
+    tags["bosh-job"] = spec.name if spec.name and not spec.name.empty?
+    tags["bosh-index"] = spec.index if spec.index
+    tags["bosh-az"] = spec.az if spec.az and not spec.az.empty?
+    tags["bosh-deployment"] = spec.deployment if spec.deployment and not spec.deployment.empty?
+end
+tags.merge!(p('tags'))
+
+if tags.any?
+%>
+tags: <%= tags.map { |k, v| "#{k}:#{v}" }.join(', ') %>
 <% end %>
 
 # Add one "dd_check:checkname" tag per running check. It makes it possible to slice


### PR DESCRIPTION
Add the property include_bosh_tags which will extend the tags reported by the agent with the metadata from the [bosh spec object](https://bosh.io/docs/jobs.html)

Currently we add the tags: bosh-job (spec.name), bosh-index, bosh-az and
bosh-deployment.


These tags can still be overriden by defining them in the `tags` property