### PR TITLE
Add option to set hostname with bosh name.index

### DIFF
--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -22,6 +22,9 @@ properties:
     description: Collect AWS EC2 custom tags as agent tags (requires an IAM role associated with the instance)
   hostname:
     description: Hostname as it should be displayed within datadog. Optional.
+  use_bosh_hostname:
+    description: When enabled, set Hostname as it should be displayed in datadog as $jobname.$index (e.g router.0).
+    default: false
   use_dogstatsd:
     default: yes
     description: Should the dogstatsd agent be started
@@ -29,7 +32,7 @@ properties:
     default: {}
     description: A dictionary of tag names and values for categories that will be applied to the data sent from this agent.
   include_bosh_tags:
-    description: Collect bosh spec metadata of the instance job, index and az. These can be overriden by setting them in tags.
+    description: Collect bosh spec metadata of the instance id, job, index and az. These can be overriden by setting them in tags.
     default: false
   integrations:
     default: {}

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -20,15 +20,27 @@ dd_url: https://app.datadoghq.com
 # https://app.datadoghq.com/account/settings
 api_key: <%= p('api_key') %>
 
-<% if_p('hostname') do %>
 # Force the hostname to whatever you want.
-hostname: <%= p('hostname') %>
+<%
+hostname = nil
+if_p('use_bosh_hostname') do |h|
+    hostname = "#{spec.name || 'unknown'}.#{spec.index || '0'}"
+end
+if_p('hostname') do |h|
+    hostname = h
+end
+
+if hostname
+%>
+hostname: <%= hostname %>
 <% end %>
 
+# <%= spec %>
 # Set the host's tags
 <%
 tags = {}
 if p('include_bosh_tags')
+    tags["bosh-id"] = spec.id if spec.id and not spec.id.empty?
     tags["bosh-job"] = spec.name if spec.name and not spec.name.empty?
     tags["bosh-index"] = spec.index if spec.index
     tags["bosh-az"] = spec.az if spec.az and not spec.az.empty?


### PR DESCRIPTION
Setting `use_bosh_hostname` will change the hostname as it should be displayed in datadog as $jobname.$index, from the spec struct.

If for some reason they are unknown (e.g. bosh-init) they will be set to `unknown`. In that case the user should use `hostname`.

The property `hostname` still takes precedence.

We also add the tag `bosh-id` when `include_bosh_tags` is set to be able to uniquely identify the instance.

We cannot get the real hostname (bosh-agent-id) in the template generation due limitations in bosh.