### PR TITLE
Allow specify a different tag prefix for bosh tags

### DIFF
--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -34,6 +34,9 @@ properties:
   include_bosh_tags:
     description: Collect bosh spec metadata of the instance id, job, index and az. These can be overriden by setting them in tags.
     default: false
+  bosh_tags_prefix:
+    description: Prefix for the tags collected from bosh spec metadata. Can be an empty string.
+    default: "bosh-"
   integrations:
     default: {}
     description: |

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -35,7 +35,6 @@ if hostname
 hostname: <%= hostname %>
 <% end %>
 
-# <%= spec %>
 # Set the host's tags
 <%
 tags = {}

--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -40,11 +40,12 @@ hostname: <%= hostname %>
 <%
 tags = {}
 if p('include_bosh_tags')
-    tags["bosh-id"] = spec.id if spec.id and not spec.id.empty?
-    tags["bosh-job"] = spec.name if spec.name and not spec.name.empty?
-    tags["bosh-index"] = spec.index if spec.index
-    tags["bosh-az"] = spec.az if spec.az and not spec.az.empty?
-    tags["bosh-deployment"] = spec.deployment if spec.deployment and not spec.deployment.empty?
+    bosh_tags_prefix=p('bosh_tags_prefix')
+    tags["#{bosh_tags_prefix}id"] = spec.id if spec.id and not spec.id.empty?
+    tags["#{bosh_tags_prefix}job"] = spec.name if spec.name and not spec.name.empty?
+    tags["#{bosh_tags_prefix}index"] = spec.index if spec.index
+    tags["#{bosh_tags_prefix}az"] = spec.az if spec.az and not spec.az.empty?
+    tags["#{bosh_tags_prefix}deployment"] = spec.deployment if spec.deployment and not spec.deployment.empty?
 end
 tags.merge!(p('tags'))
 


### PR DESCRIPTION
Configure the prefix used for the bosh tags for the Bosh spec metadata.

This will allow the user to correlate the tags with metrics from other sources. For instance, for metrics from the [Cloud Foundry DataDog nozzle](https://github.com/cloudfoundry-incubator/datadog-firehose-nozzle)

We keep `bosh-` as default