### PR TITLE
Prepend deployment name to hostname

### DIFF
--- a/jobs/datadog-agent/templates/config/datadog.conf.erb
+++ b/jobs/datadog-agent/templates/config/datadog.conf.erb
@@ -24,13 +24,13 @@ api_key: <%= p('api_key') %>
 <%
 hostname = nil
 if_p('use_bosh_hostname') do |h|
-    hostname = "#{spec.name || 'unknown'}.#{spec.index || '0'}"
+  hostname = "#{[spec.deployment, spec.name, spec.index].join('.')}"
 end
 if_p('hostname') do |h|
     hostname = h
 end
 
-if hostname
+if hostname && !hostname.empty?
 %>
 hostname: <%= hostname %>
 <% end %>


### PR DESCRIPTION
If reporting from multiple deployments that happen to use the same job
names, Datadog will get confused.

For example, we have 2 Concourse deployments. Whichever instance starts
the datadog-agent jobs last will be considered the "real" e.g. worker.0
or db.0 and the other deployment will "refuse" to report metrics for that
instance name.