### PR TITLE
Enable 3rd party release custom checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ For example:
 
 The script will use [spruce](https://github.com/geofffranks/spruce) to merge all the configurations in one unique file per check, as datadog agent expects. Merging the config with spruces allows multiple jobs add configuration for some checks, for instance to monitor different processes. Additionally the release developer can use [the spruce syntax](https://github.com/geofffranks/spruce) if the need to, although default merge strategy is good enough.
 
+#### Using custom checks from 3rd party releases
+
+This release has built-in logic that collects custom datadog checks from 3rd party releases and copies them to `checks.d` directory of the datadog agent. Configuration for these custom checks is transferred/merged using logic described above in [Configuring integrations from 3rd party releases]. The custom checks are collected from this path in the releases:
+
+  ${JOB_PATH}/config/datadog-integrations/${checkname}.py
+
+E.g.
+
+  /var/vcap/jobs/datadog-bbs/config/datadog-integrations/bbs_check.py
+
+If there happen to be two custom checks with the same name, script will abort startup, causing BOSH to fail deploying this job. This is because checks are written in python and are not easily mergable like yaml files. Overwritting checks is not desired, nor is silent failure.
+
 ## Development
 
 As a developer of this release, create new releases and upload them:

--- a/jobs/datadog-agent/spec
+++ b/jobs/datadog-agent/spec
@@ -14,6 +14,7 @@ templates:
   helpers/ctl_utils.sh: helpers/ctl_utils.sh
   helpers/merge_integrations_conf.sh: helpers/merge_integrations_conf.sh
   helpers/generate_integrations_conf.sh: helpers/generate_integrations_conf.sh
+  helpers/collect_custom_checks.sh: helpers/collect_custom_checks.sh
 
 properties:
   api_key:

--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -18,6 +18,7 @@ case $1 in
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
     bash $JOB_DIR/helpers/generate_integrations_conf.sh
     bash $JOB_DIR/helpers/merge_integrations_conf.sh
+    bash $JOB_DIR/helpers/collect_custom_checks.sh
 
     export PYTHONPATH="$AGENT_DIR/checks/libs:$PYTHONPATH"
     export LANG=POSIX

--- a/jobs/datadog-agent/templates/helpers/collect_custom_checks.sh
+++ b/jobs/datadog-agent/templates/helpers/collect_custom_checks.sh
@@ -1,0 +1,15 @@
+#!/bin/bash -eu
+
+JOBS_PATH=/var/vcap/jobs
+DD_AGENT_HOME=/var/vcap/packages/datadog-agent/agent
+
+check_files=$(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path '*/config/datadog-integrations/*\.py' -printf '%f\n' | sort)
+duplicates=$(echo "${check_files}" | uniq -cd)
+
+if [ ! -z "${duplicates}" ] ; then 
+  echo "Multiple checks with same name found: ${duplicates}. Failing custom check collection."
+  exit 1
+elif [ ! -z "${check_files}" ] ; then
+  cp $(find -L "${JOBS_PATH}" -maxdepth 4 -mindepth 4 -type f -a -path '*/config/datadog-integrations/*\.py') "${DD_AGENT_HOME}"/checks.d
+fi
+


### PR DESCRIPTION
Add logic that collects custom datadog checks from 3rd party releases.
Scripts placed in

${JOB_PATH}/config/datadog-integrations/${checkname}.py

will be copied to checks.d directory of the datadog agent. Configuration for these checks can be done using already built in 3rd party configuration merging functionality. Simply - put the config in the same directory and ensure it has `.yaml` suffix.

This functionality will break datadog-agent job startup if it finds two custom checks with the same name. This is so that it doesn't overwrite checks and doesn't fail silently when it's not clear which check should be used.

Example of use case: https://github.com/alphagov/paas-datadog-for-cloudfoundry-boshrelease/tree/master/jobs/datadog-bbs
- spec file links to check that is in the submodule. This will include it in the bosh release and it will then be picked by the collect script