### PR TITLE
Fix config and log file permissions to work with latest Bosh stemcells (3541.x)

### DIFF
--- a/jobs/datadog-agent/templates/bin/collector_ctl
+++ b/jobs/datadog-agent/templates/bin/collector_ctl
@@ -16,6 +16,8 @@ case $1 in
     pid_guard $PIDFILE $JOB_NAME
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
+
     bash $JOB_DIR/helpers/generate_integrations_conf.sh
     bash $JOB_DIR/helpers/merge_integrations_conf.sh
     bash $JOB_DIR/helpers/collect_custom_checks.sh

--- a/jobs/datadog-agent/templates/bin/dogstatsd_ctl
+++ b/jobs/datadog-agent/templates/bin/dogstatsd_ctl
@@ -9,6 +9,14 @@ export PORT=${PORT:-5000}
 export LANG=en_US.UTF-8
 PIDFILE=$RUN_DIR/dogstatsd.pid
 
+ensure_log_file_owned_by_vcap() {
+  # Make sure the dogstatsd.log file exists otherwise it will be created
+  # with owner root:root when dogstatsd.py is started the first time.
+  # The output redirection is not affected by chpst.
+  [ -e "$LOG_DIR/dogstatsd.log" ] || touch "$LOG_DIR/dogstatsd.log"
+  chown vcap:vcap "$LOG_DIR/dogstatsd.log"
+}
+
 case $1 in
 
   start)
@@ -19,6 +27,8 @@ case $1 in
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
     chown vcap:vcap "$AGENT_DIR/datadog.conf"
+
+    ensure_log_file_owned_by_vcap
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/dogstatsd.py" --use-local-forwarder \

--- a/jobs/datadog-agent/templates/bin/dogstatsd_ctl
+++ b/jobs/datadog-agent/templates/bin/dogstatsd_ctl
@@ -18,6 +18,7 @@ case $1 in
     echo $$ > $PIDFILE
 
     cp $JOB_DIR/config/datadog.conf "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
 
     exec chpst -u vcap:vcap \
       python "$AGENT_DIR/dogstatsd.py" --use-local-forwarder \

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -11,10 +11,11 @@ export LANG=en_US.UTF-8
 PIDFILE=$RUN_DIR/forwarder.pid
 
 ensure_log_file_owned_by_vcap() {
-  if [ -e "$LOG_DIR/forwarder.log" ]
-  then
-    chown vcap:vcap "$LOG_DIR/forwarder.log"
-  fi
+  # Make sure the forwarder.log file exists otherwise it will be created
+  # with owner root:root when ddagent.py is started the first time.
+  # The output redirection is not affected by chpst.
+  [ -e "$LOG_DIR/forwarder.log" ] || touch "$LOG_DIR/forwarder.log"
+  chown vcap:vcap "$LOG_DIR/forwarder.log"
 }
 
 case $1 in

--- a/jobs/datadog-agent/templates/bin/forwarder_ctl
+++ b/jobs/datadog-agent/templates/bin/forwarder_ctl
@@ -26,6 +26,7 @@ case $1 in
     echo $$ > "$PIDFILE"
 
     cp "$JOB_DIR/config/datadog.conf" "$AGENT_DIR/"
+    chown vcap:vcap "$AGENT_DIR/datadog.conf"
 
     ensure_log_file_owned_by_vcap
 


### PR DESCRIPTION
## What

* Chown the datadog.conf to vcap:vcap after copying
    * In newer Bosh stemcells (3541.x) the /var/vcap/* permissions are hardened and the datadog.conf file is not readable by the vcap user.
* Always create forwarder.log file
    * Make sure the forwarder.log file exists otherwise it will be created with owner root:root when ddagent.py is started the first time. The output redirection is not affected by chpst.
* Always create dogstatsd.log file
    * Make sure the dogstatsd.log file exists otherwise it will be created with owner root:root when dogstatsd.py is started the first time. The output redirection is not affected by chpst.